### PR TITLE
Don't error if '__session' cookie is missing

### DIFF
--- a/lib/authentication_plug.ex
+++ b/lib/authentication_plug.ex
@@ -12,13 +12,13 @@ defmodule Clerk.AuthenticationPlug do
 
   def call(conn, opts) do
     session_key = Keyword.get(opts, :session_key, "__session")
-    session = Map.get(conn.req_cookies, session_key)
 
-    with {:ok, %{"sub" => user_id} = session} <- Clerk.Session.verify_and_validate(session),
+    with {:ok, session} <- Map.fetch(conn.req_cookies, session_key),
+         {:ok, %{"sub" => user_id} = session} <- Clerk.Session.verify_and_validate(session),
          {:ok, user} <- Clerk.User.get(user_id) do
       conn |> Plug.Conn.assign(:clerk_session, session) |> Plug.Conn.assign(:current_user, user)
     else
-      {:error, _} ->
+      _ ->
         conn
         |> Plug.Conn.send_resp(401, "Unauthorized")
         |> Plug.Conn.halt()


### PR DESCRIPTION
With the current implementation, if the user is not signed in, the application fails with the following error:

```
[error] ** (FunctionClauseError) no function clause matching in Joken.verify/3
    (joken 2.6.1) lib/joken.ex:247: Joken.verify(nil, nil, [{JokenJwks, [strategy: Clerk.Session.FetchingStrategy]}, Clerk.Session])
    (joken 2.6.1) lib/joken.ex:299: Joken.verify_and_validate/5
    (clerk 1.0.0) lib/authentication_plug.ex:17: Clerk.AuthenticationPlug.call/2
```

This is because `nil` is getting passed into `Joken.verify/3`. Instead, if the `__session` cookie is missing, we just should respond with a 401 unauthorized, so that the server does not return a 500 response.