### PR TITLE
Authorization header support when cookies are not possible

### DIFF
--- a/lib/authentication_plug.ex
+++ b/lib/authentication_plug.ex
@@ -27,19 +27,19 @@ defmodule Clerk.AuthenticationPlug do
   end
 
   defp get_auth_token(conn, session_key) do
-    auth_header = get_auth_header(conn)
+    auth_header = get_token_from_header(conn)
 
-    if auth_header do
+    if auth_header do # if the auth header token is present ...
       {:ok, auth_header}
     else
-      case Map.fetch(conn.req_cookies, session_key) do
+      case Map.fetch(conn.req_cookies, session_key) do # otherwise grab the cookie
         {:ok, session} -> {:ok, session}
         _ -> {:error, :unauthorized}
       end
     end
   end
 
-  defp get_auth_header(conn) do
+  defp get_token_from_header(conn) do
     conn
     |> Plug.Conn.get_req_header("authorization")
     |> List.first()

--- a/lib/authentication_plug.ex
+++ b/lib/authentication_plug.ex
@@ -14,7 +14,7 @@ defmodule Clerk.AuthenticationPlug do
 
     session_key = Keyword.get(opts, :session_key, "__session")
 
-    with {:ok, session} <- get_auth_token(conn),
+    with {:ok, session} <- get_auth_token(conn, session_key),
          {:ok, %{"sub" => user_id} = session} <- Clerk.Session.verify_and_validate(session),
          {:ok, user} <- Clerk.User.get(user_id) do
       conn |> Plug.Conn.assign(:clerk_session, session) |> Plug.Conn.assign(:current_user, user)
@@ -26,9 +26,8 @@ defmodule Clerk.AuthenticationPlug do
     end
   end
 
-  defp get_auth_token(conn) do
+  defp get_auth_token(conn, session_key) do
     auth_header = get_auth_header(conn)
-    session_key = "__session"
 
     if auth_header do
       {:ok, auth_header}


### PR DESCRIPTION
Hi,

I am building with Expo/React Native, which requires using the Authorization header in fetch requests. I didn't immediately see the option (maybe I missed it), so I added a check in the Auth Plug.

Here is the documentation from Clerk Auth I am referencing for Expo:
https://clerk.com/docs/references/expo/read-session-user-data

Added:
- Check if the Authorization and Bearer token exists before checking the cookie.
- Manually tested both cookie-only and bearer token-only to verify that the auth plug works


Feel free to let me know if you have any questions or want to tweak the PR. 

Thanks for your hard work!

 