### PR TITLE
Name the exported env var correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Clerk
 
-HTTP client for the ClerkJS sdk. https://clerk.com/docs/reference/backend-api
+HTTP client for the ClerkJS sdk. <https://clerk.com/docs/reference/backend-api>
 
 ## Installation
 
@@ -31,7 +31,7 @@ Once the dependency is installed you can add your clerk domain and secret key to
 You can also export the secret key via bash. This is useful for local development.
 
 ```bash
-export CLERK_SECRET_KEY=sk_test_your-secret-key
+export CLERK_API_KEY=sk_test_your-secret-key
 ```
 
 ### Using dotenv in development to serve the clerk test api key
@@ -43,7 +43,7 @@ If you want to use a .env file, can use dotenv to load the config from a `.env` 
 CLERK_API_KEY=sk_somekeyabc123
 ```
 
-### In you application's supervisor:
+### In you application's supervisor
 
 ```elixir
   children = [


### PR DESCRIPTION
When the readme talks about the env var to handle the API key, it says `CLERK_API_KEY`. If we export the wrong variable, it will never take the value