### PR TITLE
Make user fetch optional in AuthenticationPlug

### DIFF
--- a/lib/authentication_plug.ex
+++ b/lib/authentication_plug.ex
@@ -1,23 +1,42 @@
 defmodule Clerk.AuthenticationPlug do
   @moduledoc """
   Plug for authenticating requests.
+
+  ## Options
+
+    * `:session_key` - the cookie name to read the session token from.
+      Defaults to `"__session"`.
+
+    * `:fetch_user` - when `true`, fetches the full user object from the
+      Clerk Backend API after token verification and assigns it as
+      `:current_user`. When `false`, builds `:current_user` from the JWT
+      claims alone (no network request). Defaults to `true`.
+
+  ## Examples
+
+      # Fetches user from Clerk API on every request (default)
+      plug Clerk.AuthenticationPlug
+
+      # Skip the API call — use JWT claims only
+      plug Clerk.AuthenticationPlug, fetch_user: false
   """
 
   @behaviour Plug
 
-  @doc """
-  Authenticates the request.
-  """
+  @impl true
   def init(opts), do: opts
 
+  @impl true
   def call(conn, opts) do
-
     session_key = Keyword.get(opts, :session_key, "__session")
+    fetch_user? = Keyword.get(opts, :fetch_user, true)
 
-    with {:ok, session} <- get_auth_token(conn, session_key),
-         {:ok, %{"sub" => user_id} = session} <- Clerk.Session.verify_and_validate(session),
-         {:ok, user} <- Clerk.User.get(user_id) do
-      conn |> Plug.Conn.assign(:clerk_session, session) |> Plug.Conn.assign(:current_user, user)
+    with {:ok, token} <- get_auth_token(conn, session_key),
+         {:ok, %{"sub" => user_id} = claims} <- Clerk.Session.verify_and_validate(token),
+         {:ok, user} <- maybe_fetch_user(user_id, claims, fetch_user?) do
+      conn
+      |> Plug.Conn.assign(:clerk_session, claims)
+      |> Plug.Conn.assign(:current_user, user)
     else
       _ ->
         conn
@@ -26,27 +45,35 @@ defmodule Clerk.AuthenticationPlug do
     end
   end
 
-  defp get_auth_token(conn, session_key) do
-    auth_header = get_token_from_header(conn)
+  defp maybe_fetch_user(user_id, _claims, true), do: Clerk.User.get(user_id)
 
-    if auth_header do # if the auth header token is present ...
-      {:ok, auth_header}
-    else
-      case Map.fetch(conn.req_cookies, session_key) do # otherwise grab the cookie
-        {:ok, session} -> {:ok, session}
-        _ -> {:error, :unauthorized}
-      end
+  defp maybe_fetch_user(_user_id, claims, false) do
+    {:ok,
+     %{
+       "id" => claims["sub"],
+       "email" => claims["email"],
+       "first_name" => claims["first_name"],
+       "last_name" => claims["last_name"]
+     }}
+  end
+
+  defp get_auth_token(conn, session_key) do
+    case get_token_from_header(conn) do
+      token when is_binary(token) ->
+        {:ok, token}
+
+      nil ->
+        case Map.fetch(conn.req_cookies, session_key) do
+          {:ok, session} -> {:ok, session}
+          _ -> {:error, :unauthorized}
+        end
     end
   end
 
   defp get_token_from_header(conn) do
-    conn
-    |> Plug.Conn.get_req_header("authorization")
-    |> List.first()
-    |> case do
-      nil -> nil
-      header -> String.replace(header, "Bearer ", "")
+    case Plug.Conn.get_req_header(conn, "authorization") do
+      ["Bearer " <> token] -> token
+      _ -> nil
     end
   end
-
 end

--- a/test/authentication_plug_test.exs
+++ b/test/authentication_plug_test.exs
@@ -1,0 +1,157 @@
+defmodule Clerk.AuthenticationPlugTest do
+  use ExUnit.Case, async: true
+  use Plug.Test
+
+  alias Clerk.AuthenticationPlug
+
+  describe "init/1" do
+    test "passes empty options through" do
+      assert AuthenticationPlug.init([]) == []
+    end
+
+    test "passes fetch_user option through" do
+      assert AuthenticationPlug.init(fetch_user: false) == [fetch_user: false]
+      assert AuthenticationPlug.init(fetch_user: true) == [fetch_user: true]
+    end
+
+    test "passes session_key option through" do
+      assert AuthenticationPlug.init(session_key: "custom") == [session_key: "custom"]
+    end
+
+    test "passes multiple options through" do
+      opts = [fetch_user: false, session_key: "my_session"]
+      assert AuthenticationPlug.init(opts) == opts
+    end
+  end
+
+  describe "call/2 with no credentials" do
+    test "returns 401 when no auth header or cookie present" do
+      conn =
+        conn(:get, "/")
+        |> AuthenticationPlug.call(AuthenticationPlug.init([]))
+
+      assert conn.status == 401
+      assert conn.halted
+    end
+
+    test "returns 401 with non-Bearer authorization header" do
+      conn =
+        conn(:get, "/")
+        |> put_req_header("authorization", "Basic abc123")
+        |> AuthenticationPlug.call(AuthenticationPlug.init([]))
+
+      assert conn.status == 401
+      assert conn.halted
+    end
+
+    test "returns 401 with empty authorization header" do
+      conn =
+        conn(:get, "/")
+        |> put_req_header("authorization", "")
+        |> AuthenticationPlug.call(AuthenticationPlug.init([]))
+
+      assert conn.status == 401
+      assert conn.halted
+    end
+
+    test "returns 401 when only Bearer prefix with no token" do
+      conn =
+        conn(:get, "/")
+        |> put_req_header("authorization", "Bearer ")
+        |> AuthenticationPlug.call(AuthenticationPlug.init([]))
+
+      # "Bearer " <> token matches with token == "", which is a binary,
+      # so it proceeds to verify_and_validate with an empty string,
+      # which will fail and return 401
+      assert conn.status == 401
+      assert conn.halted
+    end
+  end
+
+  describe "call/2 with invalid token" do
+    test "returns 401 with invalid Bearer token" do
+      conn =
+        conn(:get, "/")
+        |> put_req_header("authorization", "Bearer invalid-token")
+        |> AuthenticationPlug.call(AuthenticationPlug.init([]))
+
+      assert conn.status == 401
+      assert conn.halted
+    end
+
+    test "returns 401 with invalid cookie token using default session key" do
+      conn =
+        conn(:get, "/")
+        |> put_req_cookie("__session", "invalid-token")
+        |> fetch_cookies()
+        |> AuthenticationPlug.call(AuthenticationPlug.init([]))
+
+      assert conn.status == 401
+      assert conn.halted
+    end
+
+    test "returns 401 with invalid cookie token using custom session key" do
+      conn =
+        conn(:get, "/")
+        |> put_req_cookie("custom_session", "invalid-token")
+        |> fetch_cookies()
+        |> AuthenticationPlug.call(AuthenticationPlug.init(session_key: "custom_session"))
+
+      assert conn.status == 401
+      assert conn.halted
+    end
+  end
+
+  describe "call/2 cookie fallback" do
+    test "ignores cookie with wrong session key" do
+      conn =
+        conn(:get, "/")
+        |> put_req_cookie("wrong_key", "some-token")
+        |> fetch_cookies()
+        |> AuthenticationPlug.call(AuthenticationPlug.init([]))
+
+      # Default session_key is "__session", so "wrong_key" is ignored
+      assert conn.status == 401
+      assert conn.halted
+    end
+
+    test "cookie is not read when req_cookies are unfetched" do
+      # When fetch_cookies hasn't been called, req_cookies is %Unfetched{}
+      # and Map.fetch returns :error, so the plug returns 401
+      conn =
+        conn(:get, "/")
+        |> put_req_cookie("__session", "some-token")
+        |> AuthenticationPlug.call(AuthenticationPlug.init([]))
+
+      assert conn.status == 401
+      assert conn.halted
+    end
+  end
+
+  describe "call/2 header takes precedence over cookie" do
+    test "uses Bearer token when both header and cookie are present" do
+      # Both tokens are invalid, but this verifies the header path is taken
+      # (both paths lead to 401 since tokens are invalid, but the important
+      # thing is no crash occurs)
+      conn =
+        conn(:get, "/")
+        |> put_req_header("authorization", "Bearer header-token")
+        |> put_req_cookie("__session", "cookie-token")
+        |> fetch_cookies()
+        |> AuthenticationPlug.call(AuthenticationPlug.init([]))
+
+      assert conn.status == 401
+      assert conn.halted
+    end
+  end
+
+  describe "call/2 response body" do
+    test "returns 'Unauthorized' as response body" do
+      conn =
+        conn(:get, "/")
+        |> AuthenticationPlug.call(AuthenticationPlug.init([]))
+
+      assert conn.resp_body == "Unauthorized"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `:fetch_user` option to `Clerk.AuthenticationPlug` (defaults to `true` for backwards compatibility)
- When `false`, builds a minimal user map from JWT claims instead of calling `Clerk.User.get/1`
- Tightens Bearer token parsing to match exact `"Bearer "` prefix instead of `String.replace`
- Adds `@moduledoc` with option documentation and usage examples

## Why

The plug currently calls `Clerk.User.get/1` on **every authenticated request**, which:

1. **Adds latency** — every request waits for a round-trip to Clerk's Backend API
2. **Creates a hard dependency** — if Clerk's API is down or slow, all authentication fails
3. **Is often unnecessary** — many apps only need `user_id` and `email`, which are already in the JWT

Making this optional lets consumers choose the tradeoff between data freshness and performance/resilience.

### Bearer token parsing

`String.replace("Bearer ", "")` would incorrectly strip "Bearer " from anywhere in the header value. Pattern matching on `"Bearer " <> token` is both more correct and more idiomatic.

## Usage

```elixir
# Default — fetches full user from Clerk API (existing behavior)
plug Clerk.AuthenticationPlug

# Skip API call — use JWT claims only
plug Clerk.AuthenticationPlug, fetch_user: false
```

## Test plan

- [ ] Verify `fetch_user: true` (default) still fetches user from API
- [ ] Verify `fetch_user: false` returns claims-based user map
- [ ] Verify Bearer token extraction works correctly
- [ ] Verify cookie fallback still works